### PR TITLE
Make item.domain optional in dnsmasq_servers

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: test if dnsmasq_port is set correctly
   ansible.builtin.assert:
     that:
@@ -84,14 +83,22 @@
 - name: test if item in dnsmasq_servers is set correctly
   ansible.builtin.assert:
     that:
-      - item.domain is defined
-      - item.domain is string
       - item.nameserver is defined
       - item.nameserver is string
     quiet: yes
   loop: "{{ dnsmasq_servers }}"
   when:
     - dnsmasq_servers is defined
+
+- name: test if item.domain in dnsmasq_servers is set correctly
+  ansible.builtin.assert:
+    that:
+      - item.domain is string
+    quiet: yes
+  loop: "{{ dnsmasq_servers }}"
+  when:
+    - dnsmasq_servers is defined
+    - item.domain is defined
 
 - name: test if item.port in dnsmasq_servers is set correctly
   ansible.builtin.assert:


### PR DESCRIPTION
The `domain` bit of the `server` directive in `dnsmasq.conf` is optional.  When domain is present, an entry looks like this

`server=/foo/1.2.3.4`

and when the domain bit is absent it looks like

`server=1.2.3.4`

which has the effect of making the server a "proper" upstream server.  This is useful when combined with the `no-resolv` directive.

The template already works as desired:

```
server={% if item.domain is defined %}/{{ item.domain }}/{% endif %}{% if item.destination is defined %}{{ item.destination }}@{% endif %}{{ item.nameserver }}{% if item.interface is defined %}@{{ item.interface }}{% if item.port is defined %}#{{ item.port }}{% endif %}{% endif %}
```