### PR TITLE
Fix domain config in template

### DIFF
--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -264,7 +264,7 @@ expand-hosts
 #domain=reserved.thekelleys.org.uk,192.68.3.100,192.168.3.200
 {% if dnsmasq_domains is defined %}
 {% for item in dnsmasq_domains %}
-domain={{ item.domain }}{% if item.subnet is defined %},{{ item.subnet }}{% endif %}{% if item.from is defined %},{{ item.from }},{{ item.until }}{% endif %}
+domain={{ item.name }}{% if item.subnet is defined %},{{ item.subnet }}{% endif %}{% if item.from is defined %},{{ item.from }},{{ item.until }}{% endif %}
 
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
---
name: Fix domain config in template
about: Fixes the domain setting in dnsmasq.conf.j2

---

**Describe the change**
Currently, setting `dnsmasq_domains` as described in README.md
```
dnsmasq_domains:
  - name: thekelleys.org.uk
  - name: wireless.thekelleys.org.uk
    subnet: "192.168.2.0/24"
```
fails with
```
TASK [forked/dnsmasq : Configure dnsmasq] ********************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'domain'
fatal: [srv1.hq]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'domain'"}
```
This commit replaces `{{ item.domain }}` with `{{ item.name }}` to make the described syntax work.


**Testing**
Manual testing
