### PR TITLE
Output value of dnsmasq_hosts into template as dhcp-hosts

### DIFF
--- a/templates/dnsmasq.conf.j2
+++ b/templates/dnsmasq.conf.j2
@@ -353,6 +353,10 @@ enable-ra
 # do not matter, it's permissible to give name, address and MAC in any
 # order.
 
+{% for item in dnsmasq_hosts %}
+dhcp-host={{ item.name }},{{ item.value }}
+{% endfor %}
+
 # Always allocate the host with Ethernet address 11:22:33:44:55:66
 # The IP address 192.168.0.60
 #dhcp-host=11:22:33:44:55:66,192.168.0.60


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
The `dnsmasq_hosts` variable as allowed as an input, but the template was missing the iteration of the variable, meaning that no `dhcp-hosts` values were ever set.

**Testing**

Tested by running  a playbook locally and ensuring the values were output into `/etc/dnsmasq.conf` as expected.
